### PR TITLE
Fixed issue with packet header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ _*.pyc
 # QTCREATOR PROJECT
 *.includes
 *.creator
-*.creator.user
+*.creator.user*
 *.config
 *.files
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This package works on Ubuntu 12.04 and 14.04.
   - Replaced `decimation` options with `rate` options. Decimation is automatically calculated.
   - Added a file for use with Kalibr.
   - Added a udev rule to configure permissions.
-
 * **0.0.2**:
   - Units of acceleration are now m/s^2, in agreement with ROS convention.
   - Cleaned up code base, replaced error codes with exceptions.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This package works on Ubuntu 12.04 and 14.04.
 
 ## Version History
 
+* **0.0.4**:
+  - Fixed issue where packets would be dropped if the header checksum was broken up
+  into multiple packets.
+  - Added `verbose` option.
 * **0.0.3**:
   - Replaced `decimation` options with `rate` options. Decimation is automatically calculated.
   - Added a file for use with Kalibr.
@@ -31,6 +35,7 @@ The `imu_3dm_gx4` node supports the following base options:
 * `baudrate`: Baudrate to employ with serial communication. Defaults to `115200`.
 * `frame_id`: Frame to use in headers.
 * `imu_rate`: IMU rate to use, in Hz. Default is 100.
+* `verbose`: If true, packet reads and mismatched checksums will be logged.
 
 The following additional options are present for leveraging the 3DM's onboard estimation filter:
 * `enable_filter`: If true, the IMU estimation filter is enabled. Default is false.

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -16,8 +16,8 @@
     <arg name="baudrate" default="115200"/>
 
     <!-- Data rate in Hz -->
-    <arg name="imu_rate" default="1"/>
-    <arg name="filter_rate" default="1"/>
+    <arg name="imu_rate" default="100"/>
+    <arg name="filter_rate" default="100"/>
 
     <!-- Enable/Disable the filter -->
     <arg name="enable_filter" default="false"/>

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -16,8 +16,8 @@
     <arg name="baudrate" default="115200"/>
 
     <!-- Data rate in Hz -->
-    <arg name="imu_rate" default="100"/>
-    <arg name="filter_rate" default="100"/>
+    <arg name="imu_rate" default="1"/>
+    <arg name="filter_rate" default="1"/>
 
     <!-- Enable/Disable the filter -->
     <arg name="enable_filter" default="false"/>

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -6,6 +6,9 @@
     <!-- IMU Settings -->
     <arg name="device" default="/dev/ttyACM0" />
 
+    <!-- Verbose logging -->
+    <arg name="verbose" default="false"/>
+
     <!-- Frame ID for messages -->
     <arg name="frame_id" default="$(arg imu)"/>
 
@@ -25,6 +28,7 @@
 
     <node pkg="imu_3dm_gx4" name="$(arg imu)" type="imu_3dm_gx4" output="$(arg output)">
         <param name="device" type="string" value="$(arg device)" />
+        <param name="verbose" type="bool" value="$(arg verbose)"/>
         <param name="baudrate" type="int" value="$(arg baudrate)" />
         <param name="frame_id" type="string" value="$(arg frame_id)"/>
         <param name="imu_rate" type="int" value="$(arg imu_rate)" />

--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -10,7 +10,7 @@
     <arg name="frame_id" default="$(arg imu)"/>
 
     <!-- Baudrate of serial comms (see manual for allowed values) -->
-    <arg name="baudrate" default="921600"/>
+    <arg name="baudrate" default="115200"/>
 
     <!-- Data rate in Hz -->
     <arg name="imu_rate" default="100"/>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>imu_3dm_gx4</name>
-  <version>0.0.3</version>
+  <version>0.0.4</version>
   <description>Driver for Microstrain 3DM-GX4-25 IMU</description>
 
   <maintainer email="gcross.code@icloud.com">gcross</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -18,14 +18,12 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>galt_common</build_depend>
 
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>galt_common</run_depend>
 
   <export>
   </export>

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -894,13 +894,22 @@ int Imu::pollInput(unsigned int to) {
   return -1;
 }
 
-std::size_t Imu::handleByte(const uint8_t& byte) {
+/**
+ * @note handleByte will interpret a single byte. It will return the number
+ *  of bytes which can be cleared from the queue. On early failure, this will
+ *  always be 1 - ie. kSyncMSB should be cleared from the queue. On success, the
+ *  total length of the valid packet should be cleared.
+ */
+std::size_t Imu::handleByte(const uint8_t& byte, bool& found) {
+  found = false;
   if (state_ == Idle) {
     //  reset dstIndex_ to start of packet
     dstIndex_ = 0;
     if (byte == Imu::Packet::kSyncMSB) {
       packet_.syncMSB = byte;
       state_ = Reading;
+      //  clear previous packet out
+      memset(&packet_.payload[0], 0, sizeof(packet_.payload));
     } else {
       //  byte is no good, stay in idle
       return 1;
@@ -945,6 +954,7 @@ std::size_t Imu::handleByte(const uint8_t& byte) {
       } else {
         //  successfully read a packet
         processPacket();
+        found = true;
         return end+2;
       }
     }
@@ -962,102 +972,25 @@ int Imu::handleRead(size_t bytes_transferred) {
     queue_.push_back(buffer_[i]);
   }
   
-  while (srcIndex_ < queue_.size()) {
-    const uint8_t& head = queue_[srcIndex_];
-    const size_t clear = handleByte(head);
+  bool found = false;
+  while (srcIndex_ < queue_.size() && !found) {
+    const uint8_t head = queue_[srcIndex_];
+    const size_t clear = handleByte(head, found);
     //  pop 'clear' bytes from the queue
     for (size_t i=0; i < clear; i++) {
       queue_.pop_front();
     }
     if (clear) {
+      //  queue was shortened, return to head
       srcIndex_=0;
     } else {
+      //  continue up the queue
       srcIndex_++;
     }
   }
 
-//  if (state_ == Idle) {
-//    dstIndex_ = 0; //  reset counts
-//    srcIndex_ = 0;
-//  }
-
-//  while (srcIndex_ < queue_.size()) {
-//    if (state_ == Idle) {
-//      //   waiting for packet
-//      if (queue_.size() > 1) {
-//        if (queue_[0] == Imu::Packet::kSyncMSB &&
-//            queue_[1] == Imu::Packet::kSyncLSB) {
-//          //   found the magic ID
-//          packet_.syncMSB = queue_[0];
-//          state_ = Reading;
-
-//          //  clear out previous packet content
-//          memset(packet_.payload, 0, sizeof(packet_.payload));
-//        }
-//      }
-      
-//      queue_.pop_front();
-
-//      dstIndex_ = 1;
-//      srcIndex_ = 0;
-//    } else if (state_ == Reading) {
-//      const uint8_t& byte = queue_[srcIndex_];
-//      const size_t end = Packet::kHeaderLength + packet_.length;
-
-//      //  fill out fields of packet structure
-//      if (dstIndex_ == 1) {
-//        if (byte != Imu::Packet::kSyncLSB) {
-//          //  not a true header, throw away and go back to idle
-//          queue_.pop_front();
-//          state_ = Idle;
-//        } else {
-//          packet_.syncLSB = byte;
-//        }
-//      }
-//      else if (dstIndex_ == 2) {
-//        packet_.descriptor = byte;
-//      } 
-//      else if (dstIndex_ == 3) {
-//        packet_.length = byte;
-//      }
-//      else if (dstIndex_ < end) {
-//        packet_.payload[dstIndex_ - Packet::kHeaderLength] = byte;
-//      }
-//      else if (dstIndex_ == end) {
-//        packet_.checkMSB = byte;
-//      }
-//      else if (dstIndex_ == end + 1) {
-//        state_ = Idle; //  finished packet
-
-//        packet_.checkLSB = byte;
-
-//        //  check checksum
-//        const uint16_t sum = packet_.checksum;
-//        packet_.calcChecksum();
-
-//        if (sum != packet_.checksum) {
-//          //  invalid, go back to waiting for a marker in the stream
-//          std::cout << "Warning: Dropped packet with mismatched checksum\n"
-//                    << std::flush;
-//        } else {
-//          //  packet is valid, remove relevant data from queue
-//          for (size_t k = 0; k <= srcIndex_; k++) {
-//            queue_.pop_front();
-//          }
-
-//          //  read a packet
-//          processPacket();
-//          return 1;
-//        }
-//      }
-
-//      dstIndex_++;
-//      srcIndex_++;
-//    }
-//  }
-
   //  no packet
-  return 0;
+  return found;
 }
 
 void Imu::processPacket() {

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -1152,10 +1152,8 @@ void Imu::receiveResponse(const Packet &command, unsigned int to) {
   const auto tend = tstart + std::chrono::milliseconds(to);
 
   while (std::chrono::high_resolution_clock::now() <= tend) {
-    const auto teststart = std::chrono::high_resolution_clock::now();
-    const auto resp = pollInput(1);
-    const std::chrono::duration<float> diff = std::chrono::high_resolution_clock::now() - teststart;
-    std::cout << "pollInput blocked for " << diff.count() << " seconds\n" << std::flush;
+    const int resp = pollInput(1);
+    std::cout << "pollInput: " << resp << std::endl;
     if (resp > 0) {
       //  check if this is an ack
       const int ack = packet_.ackErrorCodeFor(command);
@@ -1165,15 +1163,17 @@ void Imu::receiveResponse(const Packet &command, unsigned int to) {
       } else if (ack > 0) {
         throw command_error(command, ack);
       } else {
+        std::cout << "Not interested in this [N]ACK!\n";
         //  this ack was not for us, keep spinning until timeout
       }
     } else if (resp < 0) {
       throw io_error(strerror(errno));
     } else {
+      std::cout << "Poll interrupted!\n";
       //  resp == 0 keep reading until timeout
     }
   }
-
+  std::cout << "Timed out!\n" << std::flush;
   //  timed out
   throw timeout_error(false, to);  
 }

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -1153,7 +1153,6 @@ void Imu::receiveResponse(const Packet &command, unsigned int to) {
 
   while (std::chrono::high_resolution_clock::now() <= tend) {
     const int resp = pollInput(1);
-    std::cout << "pollInput: " << resp << std::endl;
     if (resp > 0) {
       //  check if this is an ack
       const int ack = packet_.ackErrorCodeFor(command);
@@ -1164,6 +1163,7 @@ void Imu::receiveResponse(const Packet &command, unsigned int to) {
         throw command_error(command, ack);
       } else {
         std::cout << "Not interested in this [N]ACK!\n";
+        std::cout << packet_.toString() << "\n";
         //  this ack was not for us, keep spinning until timeout
       }
     } else if (resp < 0) {
@@ -1179,6 +1179,8 @@ void Imu::receiveResponse(const Packet &command, unsigned int to) {
 }
 
 void Imu::sendCommand(const Packet &p) {
+  std::cout << "Sending command:\n";
+  std::cout << p.toString() << std::endl;
   sendPacket(p, rwTimeout_);
   receiveResponse(p, rwTimeout_);
 }

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -1169,7 +1169,7 @@ void Imu::receiveResponse(const Packet &command, unsigned int to) {
     } else if (resp < 0) {
       throw io_error(strerror(errno));
     } else {
-      std::cout << "Poll interrupted!\n";
+      //std::cout << "Poll interrupted!\n";
       //  resp == 0 keep reading until timeout
     }
   }

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -546,37 +546,37 @@ void Imu::selectBaudRate(unsigned int baud) {
   size_t i;
   bool foundRate = false;
   for (i = 0; i < num_rates; i++) {
-    //if (verbose_){
+    if (verbose_){
       std::cout << "Switching to baud rate " << rates[i] << std::endl;
-    //}
+    }
     if (!termiosBaudRate(rates[i])) {
       throw io_error(strerror(errno));
     }
     
-    //if (verbose_) {
+    if (verbose_) {
       std::cout << "Switched baud rate to " << rates[i] << std::endl;
       std::cout << "Sending a ping packet.\n" << std::flush;
-    //}
+    }
 
     //  send ping and wait for first response
     sendPacket(pp, 100);
     try {
       receiveResponse(pp, 500);
     } catch (timeout_error&) {
-      //if (verbose_) {
+      if (verbose_) {
         std::cout << "Timed out waiting for ping response.\n" << std::flush;
-      //}
+      }
       continue;
     } catch (command_error&) {
-      //if (verbose_) {
+      if (verbose_) {
         std::cout << "IMU returned error code for ping.\n" << std::flush;
-      //}
+      }
       continue;
     } //  do not catch io_error
 
-    //if (verbose_) {
+    if (verbose_) {
       std::cout << "Found correct baudrate.\n" << std::flush;
-    //}
+    }
     
     //  no error in receiveResponse, this is correct baud rate
     foundRate = true;
@@ -600,10 +600,10 @@ void Imu::selectBaudRate(unsigned int baud) {
   comm.calcChecksum();
 
   try {
-    //if (verbose_) {
+    if (verbose_) {
       std::cout << "Instructing device to change to " << baud << std::endl
                 << std::flush;
-    //}
+    }
     sendCommand(comm);
   } catch (std::exception& e) {
     std::stringstream ss;
@@ -1002,14 +1002,14 @@ std::size_t Imu::handleByte(const uint8_t& byte, bool& found) {
 //  parses packets out of the input buffer
 int Imu::handleRead(size_t bytes_transferred) {
   //  read data into queue
+  std::stringstream ss;
+  ss << "Handling read : " << std::hex;
+  for (size_t i = 0; i < bytes_transferred; i++) {
+    queue_.push_back(buffer_[i]);
+    ss << static_cast<int>(buffer_[i]) << " ";
+  }
+  ss << std::endl;
   if (verbose_) {
-    std::stringstream ss;
-    ss << "Handling read : " << std::hex;
-    for (size_t i = 0; i < bytes_transferred; i++) {
-      queue_.push_back(buffer_[i]);
-      ss << static_cast<int>(buffer_[i]) << " ";
-    }
-    ss << std::endl;
     std::cout << ss.str() << std::flush;
   }
   
@@ -1197,7 +1197,6 @@ void Imu::receiveResponse(const Packet &command, unsigned int to) {
     } else if (resp < 0) {
       throw io_error(strerror(errno));
     } else {
-      //std::cout << "Poll interrupted!\n";
       //  resp == 0 keep reading until timeout
     }
   }

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -960,7 +960,6 @@ std::size_t Imu::handleByte(const uint8_t& byte, bool& found) {
           std::cout << static_cast<int>(q) << " ";
         }
         std::cout << "\n" << std::flush;
-        exit(10);
         return 1;
       } else {
         //  successfully read a packet

--- a/src/imu.hpp
+++ b/src/imu.hpp
@@ -280,19 +280,17 @@ public:
 
   /**
    * @brief ping Ping the device.
-   * @param to Timeout in milliseconds.
    */
   void ping();
 
   /**
    * @brief idle Switch the device to idle mode.
-   * @param to Timeout in milliseconds.
+   * @param needReply, if true we wait for reply.
    */
-  void idle();
+  void idle(bool needReply = true);
 
   /**
    * @brief resume Resume the device.
-   * @param to Timeout in milliseconds.
    */
   void resume();
 
@@ -411,7 +409,7 @@ private:
 
   void receiveResponse(const Packet &command, unsigned int to);
 
-  void sendCommand(const Packet &p);
+  void sendCommand(const Packet &p, bool readReply = true);
 
   bool termiosBaudRate(unsigned int baud);
 

--- a/src/imu.hpp
+++ b/src/imu.hpp
@@ -237,8 +237,9 @@ public:
   /**
    * @brief Imu Constructor
    * @param device Path to the device in /dev, eg. /dev/ttyACM0
+   * @param verbose If true, packet reads are logged to console.
    */
-  Imu(const std::string &device);
+  Imu(const std::string &device, bool verbose);
 
   /**
    * @brief ~Imu Destructor
@@ -415,6 +416,7 @@ private:
   bool termiosBaudRate(unsigned int baud);
 
   const std::string device_;
+  const bool verbose_;
   int fd_;
   unsigned int rwTimeout_;
 

--- a/src/imu.hpp
+++ b/src/imu.hpp
@@ -398,7 +398,7 @@ private:
 
   int pollInput(unsigned int to);
 
-  std::size_t handleByte(const uint8_t& byte);
+  std::size_t handleByte(const uint8_t& byte, bool& found);
   
   int handleRead(size_t);
 

--- a/src/imu.hpp
+++ b/src/imu.hpp
@@ -398,6 +398,8 @@ private:
 
   int pollInput(unsigned int to);
 
+  std::size_t handleByte(const uint8_t& byte);
+  
   int handleRead(size_t);
 
   void processPacket();

--- a/src/imu_3dm_gx4.cpp
+++ b/src/imu_3dm_gx4.cpp
@@ -161,6 +161,7 @@ int main(int argc, char **argv) {
   bool enableFilter;
   bool enableMagUpdate, enableAccelUpdate;
   int requestedImuRate, requestedFilterRate;
+  bool verbose;
   
   //  load parameters from launch file
   nh.param<std::string>("device", device, "/dev/ttyACM0");
@@ -171,6 +172,7 @@ int main(int argc, char **argv) {
   nh.param<bool>("enable_filter", enableFilter, false);
   nh.param<bool>("enable_mag_update", enableMagUpdate, false);
   nh.param<bool>("enable_accel_update", enableAccelUpdate, true);
+  nh.param<bool>("verbose", verbose, false);
   
   if (requestedFilterRate < 0 || requestedImuRate < 0) {
     ROS_ERROR("imu_rate and filter_rate must be > 0");
@@ -186,7 +188,7 @@ int main(int argc, char **argv) {
   }
 
   //  new instance of the IMU
-  Imu imu(device);
+  Imu imu(device, verbose);
   try {
     imu.connect();
 


### PR DESCRIPTION
These changes are in response to [issue 7](https://github.com/KumarRobotics/imu_3dm_gx4/issues/7). I will merge the changes right away, as the fix to the timeout issue has been tested by myself and @ryfallon. 

Changes:

- Fixed issue where some packets would be dropped if their header was split into two different `read()` calls.
- Fixed issue where an exception would be thrown on clean exit because the ACK for `idle()` was not read in time.
- Updated README and gitignore.

