### PR TITLE
Fixes to enable model 3DM-GX4-15

### DIFF
--- a/launch/imu.launch
+++ b/launch/imu.launch
@@ -19,6 +19,9 @@
     <arg name="imu_rate" default="100"/>
     <arg name="filter_rate" default="100"/>
 
+    <!-- Enable/Disable the magnetometer -->
+    <arg name="enable_magnetometer" default="true"/>
+
     <!-- Enable/Disable the filter -->
     <arg name="enable_filter" default="false"/>
 
@@ -33,6 +36,7 @@
         <param name="frame_id" type="string" value="$(arg frame_id)"/>
         <param name="imu_rate" type="int" value="$(arg imu_rate)" />
         <param name="filter_rate" type="int" value="$(arg filter_rate)"/>
+        <param name="enable_magnetometer" type="bool" value="$(arg enable_magnetometer)"/>
         <param name="enable_filter" type="bool" value="$(arg enable_filter)"/>
         <param name="enable_accel_update" type="bool" value="$(arg enable_accel_update)"/>
         <param name="enable_mag_update" type="bool" value="$(arg enable_mag_update)"/>

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <sstream>
 #include <stdexcept>
+#include <cstdlib>
 #include <boost/assert.hpp>
 
 extern "C" {
@@ -343,6 +344,17 @@ std::map <std::string, std::string> Imu::Info::toMap() const {
   map["Device options"] = deviceOptions;
   //  omit lot number since it is empty
   return map;
+}
+
+uint16_t Imu::Info::getModelNumber() const {
+  // Simply convert the first contiguous group of numbers into an int
+  int modelInt = atoi(modelNumber.c_str());
+  // If cannot convert, default to the -25 (6324)
+  if (!modelInt)
+  {
+    modelInt = 6324;
+  }
+  return static_cast<uint16_t>(modelInt);
 }
 
 std::map <std::string, unsigned int> Imu::DiagnosticFields::toMap() const {
@@ -715,11 +727,12 @@ void Imu::getFilterDataBaseRate(uint16_t &baseRate) {
   decode(&packet_.payload[6], 1, &baseRate);
 }
 
-void Imu::getDiagnosticInfo(Imu::DiagnosticFields &fields) {
+void Imu::getDiagnosticInfo(Imu::DiagnosticFields &fields,
+                            const Imu::Info &info) {
   Packet p(COMMAND_CLASS_3DM);
   PacketEncoder encoder(p);
   encoder.beginField(COMMAND_DEVICE_STATUS);
-  encoder.append(static_cast<uint16_t>(6234));  //  device model number
+  encoder.append(info.getModelNumber());  //  device model number
   encoder.append(u8(0x02)); //  diagnostic mode
   encoder.endField();
   p.calcChecksum();

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <sstream>
 #include <stdexcept>
-#include <cstdlib>
 #include <boost/assert.hpp>
 
 extern "C" {
@@ -348,7 +347,7 @@ std::map <std::string, std::string> Imu::Info::toMap() const {
 
 uint16_t Imu::Info::getModelNumber() const {
   // Simply convert the first contiguous group of numbers into an int
-  int modelInt = atoi(modelNumber.c_str());
+  int modelInt = std::stoi(modelNumber.c_str());
   // If cannot convert, default to the -25 (6324)
   if (!modelInt)
   {

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -347,10 +347,12 @@ std::map <std::string, std::string> Imu::Info::toMap() const {
 
 uint16_t Imu::Info::getModelNumber() const {
   // Simply convert the first contiguous group of numbers into an int
-  int modelInt = std::stoi(modelNumber.c_str());
-  // If cannot convert, default to the -25 (6324)
-  if (!modelInt)
-  {
+  int modelInt;
+  try {
+    modelInt = std::stoi(modelNumber);
+  }
+  catch (const std::invalid_argument &ex) {
+    // If cannot convert, default to the -25 (6324)
     modelInt = 6324;
   }
   return static_cast<uint16_t>(modelInt);

--- a/src/imu.hpp
+++ b/src/imu.hpp
@@ -117,9 +117,15 @@ public:
     std::string deviceOptions; /// Device options (range of the sensor)
 
     /**
-     * @brief Conver to map of human readable strings.
+     * @brief Convert to map of human readable strings.
      */
     std::map<std::string, std::string> toMap() const;
+
+    /**
+     * @brief Generate the integer model number.
+     * @return The IMU model number in integer format as expected by commands
+     */
+    uint16_t getModelNumber() const;
   };
 
   /**
@@ -315,8 +321,10 @@ public:
   /**
    * @brief getDiagnosticInfo Get diagnostic information from the IMU.
    * @param fields On success, a filled out DiagnosticFields.
+   * @param info IMU info structure with, among other things, the model number
    */
-  void getDiagnosticInfo(Imu::DiagnosticFields &fields);
+  void getDiagnosticInfo(Imu::DiagnosticFields &fields,
+                         const Imu::Info &info);
 
   /**
    * @brief setIMUDataRate Set imu data rate for different sources.

--- a/src/imu_3dm_gx4.cpp
+++ b/src/imu_3dm_gx4.cpp
@@ -24,6 +24,7 @@ std::string frameId;
 
 Imu::Info info;
 Imu::DiagnosticFields fields;
+bool enableMagnetometer;
 
 //  diagnostic_updater resources
 std::shared_ptr<diagnostic_updater::Updater> updater;
@@ -38,17 +39,22 @@ void publishData(const Imu::IMUData &data) {
   //  assume we have all of these since they were requested
   /// @todo: Replace this with a mode graceful failure...
   assert(data.fields & Imu::IMUData::Accelerometer);
-  assert(data.fields & Imu::IMUData::Magnetometer);
   assert(data.fields & Imu::IMUData::Barometer);
   assert(data.fields & Imu::IMUData::Gyroscope);
-  
+  //  only check the mag if it's enabled
+  if (enableMagnetometer) {
+    assert(data.fields & Imu::IMUData::Magnetometer);
+  }
+
   //  timestamp identically
   imu.header.stamp = ros::Time::now();
   imu.header.frame_id = frameId;
-  field.header.stamp = imu.header.stamp;
-  field.header.frame_id = frameId;
   pressure.header.stamp = imu.header.stamp;
   pressure.header.frame_id = frameId;
+  if (enableMagnetometer) {
+    field.header.stamp = imu.header.stamp;
+    field.header.frame_id = frameId;
+  }
 
   imu.orientation_covariance[0] =
       -1; //  orientation data is on a separate topic
@@ -60,16 +66,20 @@ void publishData(const Imu::IMUData &data) {
   imu.angular_velocity.y = data.gyro[1];
   imu.angular_velocity.z = data.gyro[2];
 
-  field.magnetic_field.x = data.mag[0];
-  field.magnetic_field.y = data.mag[1];
-  field.magnetic_field.z = data.mag[2];
-
   pressure.fluid_pressure = data.pressure;
+
+  if (enableMagnetometer) {
+    field.magnetic_field.x = data.mag[0];
+    field.magnetic_field.y = data.mag[1];
+    field.magnetic_field.z = data.mag[2];
+  }
 
   //  publish
   pubIMU.publish(imu);
-  pubMag.publish(field);
   pubPressure.publish(pressure);
+  if (enableMagnetometer) {
+    pubMag.publish(field);
+  }
   if (imuDiag) {
     imuDiag->tick(imu.header.stamp);
   }
@@ -138,7 +148,7 @@ void updateDiagnosticInfo(diagnostic_updater::DiagnosticStatusWrapper& stat,
   
   try {
     //  try to read diagnostic info
-    imu->getDiagnosticInfo(fields);
+    imu->getDiagnosticInfo(fields, info);
     
     auto map = fields.toMap();
     for (const std::pair<std::string, unsigned int>& p : map) {
@@ -169,6 +179,7 @@ int main(int argc, char **argv) {
   nh.param<std::string>("frame_id", frameId, std::string("imu"));
   nh.param<int>("imu_rate", requestedImuRate, 100);
   nh.param<int>("filter_rate", requestedFilterRate, 100);
+  nh.param<bool>("enable_magnetometer", enableMagnetometer, true);
   nh.param<bool>("enable_filter", enableFilter, false);
   nh.param<bool>("enable_mag_update", enableMagUpdate, false);
   nh.param<bool>("enable_accel_update", enableAccelUpdate, true);
@@ -226,11 +237,19 @@ int main(int argc, char **argv) {
     const uint16_t filterDecimation = filterBaseRate / requestedFilterRate;
     
     ROS_INFO("Selecting IMU decimation: %u", imuDecimation);
-    imu.setIMUDataRate(
-        imuDecimation, Imu::IMUData::Accelerometer | 
-          Imu::IMUData::Gyroscope |
-          Imu::IMUData::Magnetometer |
-          Imu::IMUData::Barometer);
+    std::bitset<4> imuSources = Imu::IMUData::Accelerometer |
+                                Imu::IMUData::Gyroscope |
+                                Imu::IMUData::Barometer;
+    if (enableMagnetometer)
+    {
+      ROS_INFO("Enabling magnetometer");
+      imuSources |= Imu::IMUData::Magnetometer;
+    }
+    else
+    {
+      ROS_INFO("Disabling magnetometer");
+    }
+    imu.setIMUDataRate(imuDecimation, imuSources);
 
     ROS_INFO("Selecting filter decimation: %u", filterDecimation);
     imu.setFilterDataRate(filterDecimation, Imu::FilterData::Quaternion |

--- a/src/imu_3dm_gx4.cpp
+++ b/src/imu_3dm_gx4.cpp
@@ -191,9 +191,11 @@ int main(int argc, char **argv) {
   }
   
   pubIMU = nh.advertise<sensor_msgs::Imu>("imu", 1);
-  pubMag = nh.advertise<sensor_msgs::MagneticField>("magnetic_field", 1);
   pubPressure = nh.advertise<sensor_msgs::FluidPressure>("pressure", 1);
 
+  if (enableMagnetometer) {
+    pubMag = nh.advertise<sensor_msgs::MagneticField>("magnetic_field", 1);
+  }
   if (enableFilter) {
     pubFilter = nh.advertise<imu_3dm_gx4::FilterOutput>("filter", 1);
   }


### PR DESCRIPTION
Stop hard coding model number in diagnostics request,
instead pull from device info.

Add flag to disable magnetometer (not present in the -15)

This allows me to use a 3DM-GX4-15 by simply launching with enable_magnetometer:=false (and the model number works automatically now).  I do not have any other models to test against breakages of existing functionality.